### PR TITLE
Adjust Header Format to Spec

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adif"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Evan Pratten <ewpratten@gmail.com>"]
 edition = "2018"
 description = "Amateur Data Interchange Format parsing and generation tools for Rust"

--- a/src/data.rs
+++ b/src/data.rs
@@ -183,14 +183,22 @@ pub struct AdifHeader(IndexMap<String, AdifType>);
 impl AdifHeader {
     /// Serialize into a full header string
     pub fn serialize(&self) -> Result<String, SerializeError> {
-        let mut output = self
+        let mut output = String::new();
+        output.push_str(
+            &format!("Generated {} (UTC)\n\n", chrono::Utc::now().format("%Y-%m-%d %H:%M:%S"))
+        );
+
+        let header_tags = self
             .0
             .iter()
             .map(|(key, value)| value.serialize(&key))
             .collect::<Result<Vec<String>, SerializeError>>()?
             .join("\n");
+        output.push_str(&header_tags);
+
         output.push_str("\n");
         output.push_str("<EOH>");
+
         Ok(output)
     }
 }


### PR DESCRIPTION
To mark a header in the adif-file it needs to start with any charachter
other than '<'. Usally adif-files start therefore with a comment. Added
this in the code.

I validated the exported result of limalogger against this validator
then: http://hamclubs.info/adif-validator/

So in general, this should support adif v3.0.4 at least.
